### PR TITLE
 Vagrant 2.2.17 upgrade from Ruby 2.6.7 to 3.0.1 broke vagrant-libvirt

### DIFF
--- a/vagrant/Dockerfile
+++ b/vagrant/Dockerfile
@@ -32,6 +32,7 @@ RUN curl -sSL "https://releases.hashicorp.com/vagrant/${VAGRANT_VERSION}/vagrant
 	&& rm -rf /tmp/*.deb
 
 # install the libvirt plugin
-RUN vagrant plugin install vagrant-libvirt
+# RUN vagrant plugin install vagrant-libvirt
+RUN CFLAGS="-I/opt/vagrant/embedded/include/ruby-3.0.0/ruby" vagrant plugin install vagrant-libvirt
 
 ENTRYPOINT [ "vagrant" ]


### PR DESCRIPTION
https://github.com/hashicorp/vagrant/issues/12445#issuecomment-876566065